### PR TITLE
version 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.8 - 2021-03-25
+
+### Fixed
+
+-   Solved issue where plugin `getRecaptchaKey()` variable was expecting a model that had been depreciated
+
 ## 1.0.7 - 2021-03-25
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mortscode/reviews",
     "description": "An entry reviews plugin",
     "type": "craft-plugin",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "keywords": [
         "craft",
         "cms",

--- a/src/variables/ReviewsVariable.php
+++ b/src/variables/ReviewsVariable.php
@@ -117,7 +117,7 @@ class ReviewsVariable
      *
      * @return string
      */
-    public function getRecaptchaKey(): RecaptchaModel
+    public function getRecaptchaKey(): string
     {
         return Reviews::$plugin->reviewsService->getRecaptchaKey();
     }


### PR DESCRIPTION
## 1.0.8 - 2021-03-25

### Fixed

-   Solved issue where plugin `getRecaptchaKey()` variable was expecting a model that had been depreciated